### PR TITLE
Prreferred constructor performance test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-commons</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.3.0.PERFORMANCE.TEST5</version>
 
 	<name>Spring Data Core</name>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>
 		<artifactId>spring-data-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.3.0.RELEASE</version>
 	</parent>
 
 	<properties>
@@ -25,6 +25,11 @@
 	</properties>
 
 	<dependencies>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>2.3.3</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
@@ -333,6 +338,18 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- jmh -->
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.23</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.23</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -351,6 +368,9 @@
 						<annotationProcessor>
 							com.querydsl.apt.QuerydslAnnotationProcessor
 						</annotationProcessor>
+						<annotationProcessor>
+							org.openjdk.jmh.generators.BenchmarkProcessor
+						</annotationProcessor>
 					</annotationProcessors>
 
 				</configuration>
@@ -362,6 +382,29 @@
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>benchmarks</finalName>
+							<transformers>
+								<transformer
+										implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.openjdk.jmh.Main</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 
 		</plugins>

--- a/src/test/java/org/springframework/data/mapping/PreferredConstructorPerformanceTests.java
+++ b/src/test/java/org/springframework/data/mapping/PreferredConstructorPerformanceTests.java
@@ -1,0 +1,91 @@
+package org.springframework.data.mapping;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.context.SampleMappingContext;
+
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Threads(1000)
+@Warmup(iterations = 3)
+@Fork(1)
+public class PreferredConstructorPerformanceTests {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(PreferredConstructorPerformanceTests.class.getSimpleName())
+            .build();
+
+        new Runner(opt).run();
+    }
+
+    MappingContext<?, ?> mappingContext = new SampleMappingContext();
+    PersistentEntity<?, ?> entity = mappingContext.getRequiredPersistentEntity(Person.class);
+
+    @Setup
+    public void setup() {
+        // cache
+        PersistentEntity<?, ?> entity = mappingContext.getRequiredPersistentEntity(Person.class);
+        this.executeIsConstructorParameter(entity, 1, (PreferredConstructor::isConstructorParameter));
+        this.executeIsConstructorParameter(entity, 1, (PreferredConstructor::isConstructorParameterWithConcurrencyHashMap));
+    }
+
+    @Benchmark
+    public void isConstructorParameterReadLock() {
+        this.executeIsConstructorParameter(entity, 200, (PreferredConstructor::isConstructorParameter));
+    }
+
+    @Benchmark
+    public void isConstructorParameterConcurrentHashMap() {
+        this.executeIsConstructorParameter(entity, 200, (PreferredConstructor::isConstructorParameterWithConcurrencyHashMap));
+    }
+
+    @Benchmark
+    public void isConstructorParameterConcurrentHashMapComputeIfAbsent() {
+        this.executeIsConstructorParameter(entity, 200, (PreferredConstructor::isConstructorParameterWithConcurrencyHashMapComputeIfAbsent));
+    }
+
+    private void executeIsConstructorParameter(
+        PersistentEntity<?, ?> entity, int row, BiConsumer<PreferredConstructor<?, ?>, PersistentProperty<?>> isConstructorParameter) {
+
+        for (int i = 0; i < row; i++) {
+            PreferredConstructor<?, ?> constructor = entity.getPersistenceConstructor();
+            for (PersistentProperty<?> property : entity) {
+                isConstructorParameter.accept(constructor, property);   // 15
+            }
+        }
+    }
+
+    @Data
+    @AllArgsConstructor
+    public static class Person {
+        @Id
+        private String id;
+        private String firstName;
+        private String lastName;
+        private String ssn;
+        private int age;
+        private Instant birth;
+        private boolean adult;
+        private String address;
+        private String addressDetail;
+        private String country;
+        private String state;
+        private String zipCode;
+        private String job;
+        private String company;
+        private String email;
+    }
+}


### PR DESCRIPTION
```
# JMH version: 1.23
# VM version: JDK 1.8.0_192, Java HotSpot(TM) 64-Bit Server VM, 25.192-b12
# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/jre/bin/java
# VM options: -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=50049:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8
# Warmup: 3 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1000 threads, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMap

# Run progress: 0.00% complete, ETA 00:04:00
# Fork: 1 of 1
# Warmup Iteration   1: 5.579 ±(99.9%) 0.077 ms/op
# Warmup Iteration   2: 5.463 ±(99.9%) 0.067 ms/op
# Warmup Iteration   3: 5.516 ±(99.9%) 0.091 ms/op
Iteration   1: 5.264 ±(99.9%) 0.088 ms/op
Iteration   2: 5.164 ±(99.9%) 0.068 ms/op
Iteration   3: 5.239 ±(99.9%) 0.076 ms/op
Iteration   4: 5.221 ±(99.9%) 0.081 ms/op
Iteration   5: 5.252 ±(99.9%) 0.071 ms/op


Result "org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMap":
  5.228 ±(99.9%) 0.151 ms/op [Average]
  (min, avg, max) = (5.164, 5.228, 5.264), stdev = 0.039
  CI (99.9%): [5.077, 5.379] (assumes normal distribution)


# JMH version: 1.23
# VM version: JDK 1.8.0_192, Java HotSpot(TM) 64-Bit Server VM, 25.192-b12
# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/jre/bin/java
# VM options: -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=50049:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8
# Warmup: 3 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1000 threads, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMapComputeIfAbsent

# Run progress: 33.33% complete, ETA 00:04:15
# Fork: 1 of 1
# Warmup Iteration   1: 106.450 ±(99.9%) 1.274 ms/op
# Warmup Iteration   2: 104.555 ±(99.9%) 1.336 ms/op
# Warmup Iteration   3: 99.112 ±(99.9%) 1.187 ms/op
Iteration   1: 98.715 ±(99.9%) 1.255 ms/op
Iteration   2: 98.676 ±(99.9%) 1.275 ms/op
Iteration   3: 99.171 ±(99.9%) 1.296 ms/op
Iteration   4: 100.556 ±(99.9%) 1.312 ms/op
Iteration   5: 100.264 ±(99.9%) 1.322 ms/op


Result "org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMapComputeIfAbsent":
  99.477 ±(99.9%) 3.389 ms/op [Average]
  (min, avg, max) = (98.676, 99.477, 100.556), stdev = 0.880
  CI (99.9%): [96.088, 102.866] (assumes normal distribution)


# JMH version: 1.23
# VM version: JDK 1.8.0_192, Java HotSpot(TM) 64-Bit Server VM, 25.192-b12
# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/jre/bin/java
# VM options: -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=50049:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8
# Warmup: 3 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1000 threads, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterReadLock

# Run progress: 66.67% complete, ETA 00:01:46
# Fork: 1 of 1
# Warmup Iteration   1: 716.457 ±(99.9%) 5.951 ms/op
# Warmup Iteration   2: 742.832 ±(99.9%) 5.665 ms/op
# Warmup Iteration   3: 745.476 ±(99.9%) 6.553 ms/op
Iteration   1: 753.153 ±(99.9%) 8.694 ms/op
Iteration   2: 742.263 ±(99.9%) 10.983 ms/op
Iteration   3: 774.202 ±(99.9%) 11.523 ms/op
Iteration   4: 751.586 ±(99.9%) 10.356 ms/op
Iteration   5: 751.131 ±(99.9%) 10.890 ms/op


Result "org.springframework.data.mapping.PreferredConstructorPerformanceTests.isConstructorParameterReadLock":
  754.467 ±(99.9%) 45.543 ms/op [Average]
  (min, avg, max) = (742.263, 754.467, 774.202), stdev = 11.827
  CI (99.9%): [708.924, 800.010] (assumes normal distribution)


# Run complete. Total time: 00:05:33

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                                                                    Mode  Cnt    Score    Error  Units
PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMap                 avgt    5    5.228 ±  0.151  ms/op
PreferredConstructorPerformanceTests.isConstructorParameterConcurrentHashMapComputeIfAbsent  avgt    5   99.477 ±  3.389  ms/op
PreferredConstructorPerformanceTests.isConstructorParameterReadLock                          avgt    5  754.467 ± 45.543  ms/op
```